### PR TITLE
Exception with empty ldap_password

### DIFF
--- a/addons/auth_ldap/users_ldap.py
+++ b/addons/auth_ldap/users_ldap.py
@@ -141,7 +141,7 @@ class CompanyLDAP(osv.osv):
         try:
             conn = self.connect(conf)
             conn.simple_bind_s(conf['ldap_binddn'] or '',
-                               conf['ldap_password'].encode('utf-8') or '')
+                               (conf['ldap_password'] or '').encode('utf-8'))
             results = conn.search_st(conf['ldap_base'], ldap.SCOPE_SUBTREE,
                                      filter, retrieve_attributes, timeout=60)
             conn.unbind()


### PR DESCRIPTION
Attempt to `encode` `None` variable